### PR TITLE
Firestore System changing on the Signup Screen

### DIFF
--- a/Unshackled/Views/AuthViews/SignUpViews/SignUpStage2View.swift
+++ b/Unshackled/Views/AuthViews/SignUpViews/SignUpStage2View.swift
@@ -315,7 +315,7 @@ struct SignUpStage2View: View {
         
         
         let userData = [
-            "email": SignUpVM.email,
+            
             "uid": uid,
             "name": SignUpVM.name,
             "dobDay": SignUpVM.dobDay,

--- a/Unshackled/Views/AuthViews/SignUpViews/SignUpView.swift
+++ b/Unshackled/Views/AuthViews/SignUpViews/SignUpView.swift
@@ -163,9 +163,29 @@ struct SignUpView: View {
                 print("Couldn't Create User \(err)")
                 return
             }
+            storeUserEmailInfomation()
             print("Successfully created user")
             nextStepview = true
         }
+    }
+    
+    private func storeUserEmailInfomation() {
+        guard let uid = FirebaseManager.shared.auth.currentUser?.uid else {return}
+        
+        let emailData =
+        [
+            "email": SignUpVM.email
+        ]
+        FirebaseManager.shared.firestore.collection("users")
+            .document(uid).setData(emailData) {err in
+                if let err = err {
+                    print("Could not save user email into Firestore \(err)")
+                    SignUpVM.errorMessage = "Could not save user email in Firestore \(err)"
+                    return
+                }
+                print("Saved user email into Firestore")
+                SignUpVM.errorMessage = "Saved user email into Firestore"
+            }
     }
     
     


### PR DESCRIPTION
Within the Signup/Login Screen, the firebase system is going to change as it would not saved the email due to the account creation would delete the email state before the store function could read it. So make this work, i wil to need to redo the entire signup/Login Hierarchy to fit this new system. 

Even the viewmodel doesn't save the value as the variable within the viewModel is not a state object, it only becomes a state object within the file its needed and declared there. 